### PR TITLE
Added API Key, Changed JSON Lib to Poison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /ebin
 /deps
+/_build
 erl_crash.dump

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,9 @@
-language: erlang
-env:
-  - ELIXIR="v1.0.0"
+language: elixir
+elixir:
+  - '1.5.1'
+otp_release:
+  - '20'
 notifications:
   email:
     recipients:
-      - jonah@pixelhipsters.com
-  irc:
-    channels:
-      - irc.freenode.org#rubyonadhd
-    template:
-      - "Yo yo yo yo!! Make some noise, Ta-ta-ta Travis-bot in da house motherfuckers, this build better represent!"
-      - "I Just finished testing what %{author} pushed in %{commit} to %{repository} - %{master}"
-      - "and DAYUMMM, it looks like %{message}"
-      - "Change view : %{compare_url}"
-      - "Build details : %{build_url}"
-    skip_join: true
-otp_release:
-  - 17.0
-  - 17.1
-before_install:
-  - mkdir -p vendor/elixir
-  - wget -q https://github.com/elixir-lang/elixir/releases/download/$ELIXIR/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir
-  - export PATH="$PATH:$PWD/vendor/elixir/bin"
-  - mix local.hex --force
-  - mix local.rebar
-script: "MIX_ENV=test mix do deps.get, test"
-
+      - inicsmith@gmail.com 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: elixir
 elixir:
   - '1.5.1'
 otp_release:
-  - '20'
+  - '20.1'
 notifications:
   email:
     recipients:
-      - inicsmith@gmail.com 
+      - inicsmith@gmail.com

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Written in Elixir.
 
 Get an API key https://developers.google.com/url-shortener/v1/getting_started#APIKey
 
-Add an environment variable GOOGLE_URL_SHORTENER_API_KEY=KEYGOESHERE or open the config dir
-and add the key in the config files.
+Add an environment variable GOOGLE_URL_SHORTENER_API_KEY=KEYGOESHERE
+
+config :link_shrinkex,
+  google_url_shortner_api_key: System.get_env("GOOGLE_URL_SHORTENER_API_KEY")
 
 Fetching dependencies and running on elixir console:
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ Written in Elixir.
 
 Get an API key https://developers.google.com/url-shortener/v1/getting_started#APIKey
 
-Add an environment variable GOOGLE_URL_SHORTENER_API_KEY=KEYGOESHERE
+Add an environment variable GOOGLE_URL_SHORTENER_API_KEY=YOUR_KEY_GOES_HERE
+
+Add the following config to your config files
 
 config :link_shrinkex,
   google_url_shortner_api_key: System.get_env("GOOGLE_URL_SHORTENER_API_KEY")
+
 
 Fetching dependencies and running on elixir console:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LinkShrinkex (v1.0.0) [![Build Status](https://travis-ci.org/jonahoffline/link_shrinkex.png?branch=master)](https://travis-ci.org/jonahoffline/link_shrinkex)
+# LinkShrinkex (v2.0.0) [![Build Status](https://travis-ci.org/inicsmith/link_shrinkex.svg?branch=master)](https://travis-ci.org/inicsmith/link_shrinkex)
 
 
 Create short URLs using Google's URL Shortener API.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Written in Elixir.
 
 ## Quickstart ##
 
+Get an API key https://developers.google.com/url-shortener/v1/getting_started#APIKey
+
+Add an environment variable GOOGLE_URL_SHORTENER_API_KEY=KEYGOESHERE or open the config dir
+and add the key in the config files.
+
 Fetching dependencies and running on elixir console:
 
 ```console

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,5 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :link_shrinkex, google_url_shortner_api_key: System.get_env("GOOGLE_URL_SHORTENER_API_KEY")

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :link_shrinkex, google_url_shortner_api_key: System.get_env("GOOGLE_URL_SHORTENER_API_KEY")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :link_shrinkex, google_url_shortner_api_key: System.get_env("GOOGLE_URL_SHORTENER_API_KEY")

--- a/mix.exs
+++ b/mix.exs
@@ -1,20 +1,22 @@
 defmodule LinkShrinkex.Mixfile do
   use Mix.Project
 
+  @version "1.0.1"
+
   def project do
     [ app: :link_shrinkex,
-      version: String.strip(File.read!("VERSION")),
+      version: @version,
       elixir: "~> 1.0",
-      deps: deps,
+      deps: deps(),
       source_url: "https://github.com/jonahoffline/link_shrinkex",
-      description: description,
-      package: package
+      description: description(),
+      package: package()
     ]
   end
 
   # Configuration for the OTP application
   def application do
-    [applications: [:jsex, :inets, :ssl]]
+    [applications: [:inets, :ssl]]
   end
 
   defp description do
@@ -31,6 +33,6 @@ defmodule LinkShrinkex.Mixfile do
 
   # Returns the list of dependencies in the format:
   defp deps do
-    [{ :jsex, "2.1.0", github: "talentdeficit/jsex" }]
+    [{:poison, "~> 3.1"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LinkShrinkex.Mixfile do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "2.0.0"
 
   def project do
     [ app: :link_shrinkex,

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,1 @@
-%{"jsex": {:git, "git://github.com/talentdeficit/jsex.git", "4f9d46b77567a48282a3477f87ab72faf6bd1721", []},
-  "jsx": {:package, "2.1.1"}}
+%{"poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"}}

--- a/test/link_shrinkex_test.exs
+++ b/test/link_shrinkex_test.exs
@@ -10,8 +10,8 @@ defmodule LinkShrinkexTest do
   test ".shrink_url returns correct response" do
     LinkShrinkex.start
 
-    assert LinkShrinkex.shrink_url("http://www.elixir-lang.org") == { :ok, "http://goo.gl/Shz0u" }
-    assert LinkShrinkex.shrink_url("http://www.elixir-lang.org", []) == { :ok, "http://goo.gl/Shz0u" }
+    assert LinkShrinkex.shrink_url("http://www.elixir-lang.org") == { :ok, "https://goo.gl/Shz0u" }
+    assert LinkShrinkex.shrink_url("http://www.elixir-lang.org", []) == { :ok, "https://goo.gl/Shz0u" }
   end
 
 
@@ -20,34 +20,34 @@ defmodule LinkShrinkexTest do
   test "returns short_url with [:short_url] option" do
     LinkShrinkex.start
 
-    assert LinkShrinkex.shrink_url("http://www.elixir-lang.org", [:short_url]) == "http://goo.gl/Shz0u"
+    assert LinkShrinkex.shrink_url("http://www.elixir-lang.org", [:short_url]) == "https://goo.gl/Shz0u"
   end
 
   test "returns short and long urls with [:urls] option" do
     LinkShrinkex.start
 
-    expected_response_urls = { :ok, %{id: "http://goo.gl/Shz0u", longUrl: "http://www.elixir-lang.org/"} }
+    expected_response_urls = { :ok, %{id: "https://goo.gl/Shz0u", longUrl: "http://www.elixir-lang.org/"} }
     assert LinkShrinkex.shrink_url("http://www.elixir-lang.org", [:urls]) == expected_response_urls
   end
 
   test "returns parsed JSON with [:json] option" do
     LinkShrinkex.start
 
-    expected_response = {:ok,"{\"id\":\"http://goo.gl/Shz0u\",\"kind\":\"urlshortener#url\",\"longUrl\":\"http://www.elixir-lang.org/\"}"}
+    expected_response = {:ok, "{\"longUrl\":\"http://www.elixir-lang.org/\",\"kind\":\"urlshortener#url\",\"id\":\"https://goo.gl/Shz0u\"}"}
     assert LinkShrinkex.shrink_url("http://www.elixir-lang.org", [:json]) == expected_response
   end
 
   test "returns list with [:list] option" do
     LinkShrinkex.start
 
-    expected_response = {:ok,%{id: "http://goo.gl/Shz0u", kind: "urlshortener#url", longUrl: "http://www.elixir-lang.org/"}}
+    expected_response = {:ok,%{id: "https://goo.gl/Shz0u", kind: "urlshortener#url", longUrl: "http://www.elixir-lang.org/"}}
     assert LinkShrinkex.shrink_url("http://www.elixir-lang.org", [:list]) == expected_response
   end
 
   test "returns default response with non-existant option" do
     LinkShrinkex.start
 
-    assert LinkShrinkex.shrink_url("http://www.elixir-lang.org", [:non_existant]) == { :ok, "http://goo.gl/Shz0u" }
+    assert LinkShrinkex.shrink_url("http://www.elixir-lang.org", [:non_existant]) == { :ok, "https://goo.gl/Shz0u" }
   end
 
 
@@ -104,4 +104,3 @@ defmodule LinkShrinkexTest do
     end
   end
 end
-

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,5 @@
+language: elixir
+elixir:
+  - '1.5.1' 
+otp_release:
+  - '20'

--- a/travis.yml
+++ b/travis.yml
@@ -1,5 +1,0 @@
-language: elixir
-elixir:
-  - '1.5.1' 
-otp_release:
-  - '20'


### PR DESCRIPTION
Hi,

I ran into a few issues trying to use link_shrinkex today.

- When I pulled from hex and used it in an umbrella app it couldn't find the VERSION file.  It worked locally from GitHub though. 
- I needed to add key support because without an API key I was getting a "dailyLimitExceededUnreg" error.
- I changed the JSON library because I ran into an issue with the version and thought Poison was more active. 
- I also fixed a few things minor were causing warnings. 